### PR TITLE
Update message storage format

### DIFF
--- a/archive/access_api.py
+++ b/archive/access_api.py
@@ -69,7 +69,7 @@ class Archive_access():
         if bundle is None:
             return None
         bundle =  bson.loads(bundle)
-        message = bundle["message"]["content"]
+        message = bundle["message"]
         metadata = bundle["metadata"]
         return (message, metadata)
 

--- a/archive/consumer_api.py
+++ b/archive/consumer_api.py
@@ -108,7 +108,7 @@ class Mock_consumer(Base_consumer):
             yield message
 
     def queue(self, message: bytes, metadata):
-        self.messages.append(({"format": "dummy", "content": message}, metadata))
+        self.messages.append((message, metadata))
 
 
 class Hop_consumer(Base_consumer):
@@ -219,10 +219,7 @@ class Hop_consumer(Base_consumer):
         while keep_going:
             keep_going = False
             self.connect()
-            for message, metadata in self.client.read(metadata=True, autocommit=False):
-                # TODO: It would be nice for hop to support a 'raw read' so we don't have to do this
-                message = message.serialize()
-            
+            for message, metadata in self.client.read_raw(metadata=True, autocommit=False):
                 self.n_recieved += 1
                 yield (message, metadata)
                 url_changed = self.refresh_url()

--- a/archive/decision_api.py
+++ b/archive/decision_api.py
@@ -33,7 +33,7 @@ async def is_content_identical(ids, db, store):
     for bucket, key in locations:
         content = bson.loads(await store.get_object(key))
         contents.append(content)
-    crc_set = {zlib.crc32(c["message"]["content"]) for c in contents}
+    crc_set = {zlib.crc32(c["message"]) for c in contents}
     return len(crc_set) == 1
 
 
@@ -72,7 +72,7 @@ def get_annotations(message, headers=[], public: bool=True, direct_upload: bool=
 	text_uuid, is_client_uuid  = get_text_uuid(headers)
 	annotations["con_text_uuid"] = text_uuid
 	annotations["con_is_client_uuid"] = is_client_uuid
-	annotations["con_message_crc32"] =  zlib.crc32(message["content"])
+	annotations["con_message_crc32"] =  zlib.crc32(message)
 	annotations["public"] =  public
 	annotations["direct_upload"] =  direct_upload
 	return annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "cython<3 ; python_version < '3.8'", # need this to work around https://github.com/fastavro/fastavro/issues/701
     "fastapi",
     "fastavro~=1.7.0 ; python_version < '3.8'", # need this to work around https://github.com/fastavro/fastavro/issues/701
-    "hop-client",
+    "hop-client>=0.9.0",
     "httpx",
     "psycopg[binary]",
     "psycopg_pool",

--- a/tests/test_access_api.py
+++ b/tests/test_access_api.py
@@ -62,7 +62,7 @@ async def test_archive_access_store_message():
     await aa.connect()
     
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
     r = await aa.store_message(message, metadata)
     assert r[0], "Insertion should succeed"
@@ -75,7 +75,7 @@ async def test_archive_access_store_message():
     sr = await aa.store.get_object(dr.key)
     assert sr is not None, "Message should be in data store"
     data = bson.loads(sr)
-    assert data["message"]["content"] == message["content"]
+    assert data["message"] == message
     assert data["annotations"]["con_text_uuid"] == str(u)
 
 @pytest.mark.asyncio
@@ -83,7 +83,7 @@ async def test_archive_access_store_message_no_uuid():
     aa = access_api.Archive_access(get_mock_config())
     await aa.connect()
     
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[], _raw=None)
     r = await aa.store_message(message, metadata)
     assert r[0], "Insertion should succeed"
@@ -96,7 +96,7 @@ async def test_archive_access_store_message_no_uuid():
     sr = await aa.store.get_object(dr[0].key)
     assert sr is not None, "Message should be in data store"
     data = bson.loads(sr)
-    assert data["message"]["content"] == message["content"]
+    assert data["message"] == message
 
 @pytest.mark.asyncio
 async def test_archive_access_store_message_duplicate_uuid():
@@ -104,7 +104,7 @@ async def test_archive_access_store_message_duplicate_uuid():
     await aa.connect()
     
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
     r = await aa.store_message(message, metadata)
     assert r[0], "Insertion should succeed"
@@ -117,7 +117,7 @@ async def test_archive_access_store_message_duplicate_wo_uuid():
     aa = access_api.Archive_access(get_mock_config())
     await aa.connect()
     
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[], _raw=None)
     r = await aa.store_message(message, metadata)
     assert r[0], "Insertion should succeed"
@@ -131,7 +131,7 @@ async def test_archive_access_get_metadata():
     await aa.connect()
     
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
     r = await aa.store_message(message, metadata)
     assert r[0], "Insertion should succeed"
@@ -146,7 +146,7 @@ async def test_archive_access_get_metadata():
 async def test_archive_access_get_metadata_for_time_range():
     messages = []
     for i in range(0,10):
-        ms = {"content":b"datadatadata"}
+        ms = b"datadatadata"
         md = Metadata(topic="t1", partition=0, offset=i, timestamp=i, key="", headers=[("_id",uuid.uuid4().bytes)], _raw=None)
         messages.append((ms,md))
     
@@ -184,7 +184,7 @@ async def test_archive_access_get_object_lazily():
     await aa.connect()
     
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
     r = await aa.store_message(message, metadata)
     
@@ -194,7 +194,7 @@ async def test_archive_access_get_object_lazily():
     assert isinstance(r, store_api.Mock_store.LazyObject)
     obj = r.read()
     data = bson.loads(obj)
-    assert data["message"]["content"] == message["content"]
+    assert data["message"] == message
     
     not_found = await aa.get_object_lazily("some invalid key")
     assert not_found is None
@@ -205,7 +205,7 @@ async def test_archive_access_get_raw_object():
     await aa.connect()
     
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
     r = await aa.store_message(message, metadata)
     
@@ -213,7 +213,7 @@ async def test_archive_access_get_raw_object():
     obj = await aa.get_raw_object(key)
     assert obj is not None, "Message should be found"
     data = bson.loads(obj)
-    assert data["message"]["content"] == message["content"]
+    assert data["message"] == message
     
     not_found = await aa.get_raw_object("some invalid key")
     assert not_found is None
@@ -224,7 +224,7 @@ async def test_archive_access_get_all():
     await aa.connect()
     
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
     r = await aa.store_message(message, metadata)
     assert r[0], "Insertion should succeed"
@@ -233,7 +233,7 @@ async def test_archive_access_get_all():
     r = await aa.get_all(key)
     assert r is not None, "Message should be found"
     message_out, metadata_out = r
-    assert message_out == message["content"]
+    assert message_out == message
     assert metadata_out["topic"] == metadata.topic
     assert metadata_out["timestamp"] == metadata.timestamp
     
@@ -246,7 +246,7 @@ async def test_archive_access_get_as_sent():
     await aa.connect()
     
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
     r = await aa.store_message(message, metadata)
     
@@ -254,7 +254,7 @@ async def test_archive_access_get_as_sent():
     r = await aa.get_as_sent(key)
     assert r is not None, "Message should be found"
     message_out, headers_out = r
-    assert message_out == message["content"]
+    assert message_out == message
     assert len(headers_out) == len(metadata.headers)
     assert len(headers_out[0]) == len(metadata.headers[0])
     assert headers_out[0][0] == metadata.headers[0][0]
@@ -269,7 +269,7 @@ async def test_archive_access_get_object_summary():
     await aa.connect()
     
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    message = {"content":b"datadatadata"}
+    message = b"datadatadata"
     metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
     r = await aa.store_message(message, metadata)
     

--- a/tests/test_database_api.py
+++ b/tests/test_database_api.py
@@ -156,7 +156,7 @@ async def test_SQL_db_insert_readonly(tmpdir):
 @pytest.mark.asyncio
 async def test_SQL_db_insert(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -189,7 +189,7 @@ async def test_SQL_db_insert(tmpdir):
 @pytest.mark.asyncio
 async def test_SQL_db_fetch(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -220,7 +220,7 @@ async def test_SQL_db_fetch(tmpdir):
 @pytest.mark.asyncio
 async def test_SQL_db_uuid_in_db(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -238,7 +238,7 @@ async def test_SQL_db_uuid_in_db(tmpdir):
 @pytest.mark.asyncio
 async def test_SQL_db_exists_in_db(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -256,11 +256,11 @@ async def test_SQL_db_exists_in_db(tmpdir):
 @pytest.mark.asyncio
 async def test_SQL_db_uuid_duplicates(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	m1 = {"content":b"datadatadata"}
+	m1 = b"datadatadata"
 	meta1 = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	a1 = decision_api.get_annotations(m1, meta1.headers)
 	
-	m2 = {"content":b"otherdata"}
+	m2 = b"otherdata"
 	meta2 = Metadata(topic="t2", partition=0, offset=4, timestamp=19, key="", headers=[("_id",u.bytes)], _raw=None)
 	a2 = decision_api.get_annotations(m2, meta2.headers)
 
@@ -288,12 +288,12 @@ async def test_SQL_db_uuid_duplicates(tmpdir):
 @pytest.mark.asyncio
 async def test_SQL_db_content_duplicates(tmpdir):
 	u1 = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	m1 = {"content":b"datadatadata"}
+	m1 = b"datadatadata"
 	meta1 = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u1.bytes)], _raw=None)
 	a1 = decision_api.get_annotations(m1, meta1.headers)
 	
 	u2 = uuid.UUID("76543210-ffff-eeee-dddd-9876543210ba")
-	m2 = {"content":b"datadatadata"}
+	m2 = b"datadatadata"
 	meta2 = Metadata(topic="t1", partition=0, offset=4, timestamp=356, key="", headers=[("_id",u2.bytes)], _raw=None)
 	a2 = decision_api.get_annotations(m2, meta2.headers)
 
@@ -323,7 +323,7 @@ async def test_SQL_db_content_duplicates(tmpdir):
 @pytest.mark.asyncio
 async def test_SQL_db_get_message_id(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -344,7 +344,7 @@ async def test_SQL_db_get_message_id(tmpdir):
 @pytest.mark.asyncio
 async def test_SQL_db_get_message_locations(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -368,7 +368,7 @@ async def test_SQL_db_get_message_records_for_time_range(tmpdir):
 	messages = []
 	st = await get_mock_store()
 	for i in range(0,10):
-		ms = {"content":b"datadatadata"}
+		ms = b"datadatadata"
 		md = Metadata(topic="t1", partition=0, offset=i, timestamp=i, key="", headers=[("_id",uuid.uuid4().bytes)], _raw=None)
 		an = decision_api.get_annotations(ms, md.headers)
 		await st.store(ms, md, an)
@@ -448,7 +448,7 @@ async def test_Base_db_unimlemented():
 @pytest.mark.asyncio
 async def test_Mock_db_get_message_id():
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -478,7 +478,7 @@ async def test_Mock_db_insert_readonly():
 @pytest.mark.asyncio
 async def test_Mock_db_fetch():
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 

--- a/tests/test_decision_api.py
+++ b/tests/test_decision_api.py
@@ -21,11 +21,11 @@ async def test_is_content_identical():
     await db.connect()
     await st.connect()
     
-    m1 = ({"content":b"abcdefgh"},
+    m1 = (b"abcdefgh",
           Metadata(topic="t1", partition=0, offset=0, timestamp=172, key="", headers=[], _raw=None))
-    m2 = ({"content":b"abcdefgh"},
+    m2 = (b"abcdefgh",
           Metadata(topic="t1", partition=0, offset=1, timestamp=223, key="", headers=[], _raw=None))
-    m3 = ({"content":b"somethingelse"},
+    m3 = (b"somethingelse",
           Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[], _raw=None))
     
     async def store(payload, metadata):
@@ -67,7 +67,7 @@ def test_get_text_uuid():
 def test_get_annotations():
     get_annotations = decision_api.get_annotations
 
-    m1 = ({"content":b"abcdefgh"},[])
+    m1 = (b"abcdefgh",[])
     a1 = get_annotations(m1[0], m1[1])
     assert "con_text_uuid" in a1
     uuid.UUID(a1["con_text_uuid"])
@@ -76,7 +76,7 @@ def test_get_annotations():
     assert "con_message_crc32" in a1
     
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    m2 = ({"content":b"0123456789"},[("_id",u.bytes)])
+    m2 = (b"0123456789",[("_id",u.bytes)])
     a2 = get_annotations(m2[0], m2[1])
     assert "con_text_uuid" in a2
     assert uuid.UUID(a2["con_text_uuid"]) == u
@@ -100,12 +100,12 @@ async def test_is_deemed_duplicate():
     await db.connect()
     await st.connect()
     
-    m1 = ({"content":b"abcdefgh"},
+    m1 = (b"abcdefgh",
           Metadata(topic="t1", partition=0, offset=0, timestamp=172, key="", headers=[], _raw=None))
-    m2 = ({"content":b"abcdefgh"},
+    m2 = (b"abcdefgh",
           Metadata(topic="t1", partition=0, offset=1, timestamp=172, key="", headers=[], _raw=None))
     u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-    m3 = ({"content":b"somethingelse"},
+    m3 = (b"somethingelse",
           Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None))
     
     async def store(payload, metadata, annotations):

--- a/tests/test_store_api.py
+++ b/tests/test_store_api.py
@@ -73,7 +73,7 @@ async def test_S3_store_startup(tmpdir):
 @pytest.mark.asyncio
 async def test_S3_store_store_get(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -89,7 +89,7 @@ async def test_S3_store_store_get(tmpdir):
 		obj = await st.get_object(annotations["key"])
 		assert obj is not None, "Message should be found"
 		data = bson.loads(obj)
-		assert data["message"]["content"] == message["content"]
+		assert data["message"] == message
 		
 		not_found = await st.get_object("some invalid key")
 		assert not_found is None
@@ -99,7 +99,7 @@ async def test_S3_store_store_get(tmpdir):
 @pytest.mark.asyncio
 async def test_S3_store_store_readonly(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -117,7 +117,7 @@ async def test_S3_store_store_readonly(tmpdir):
 @pytest.mark.asyncio
 async def test_S3_store_get_lazily(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadatadata"*64}
+	message = b"datadatadatadata"*64
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -133,7 +133,7 @@ async def test_S3_store_get_lazily(tmpdir):
 		async for chunk in result['Body']:
 			output.write(chunk)
 		data = bson.loads(output.getvalue())
-		assert data["message"]["content"] == message["content"]
+		assert data["message"] == message
 		
 		result = await st.get_object_lazily("a-non-existent-key")
 		assert result is None
@@ -143,7 +143,7 @@ async def test_S3_store_get_lazily(tmpdir):
 @pytest.mark.asyncio
 async def test_S3_store_get_object_summary(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadatadata"*64}
+	message = b"datadatadatadata"*64
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -171,7 +171,7 @@ async def test_S3_store_get_object_summary(tmpdir):
 @pytest.mark.asyncio
 async def test_Mock_store_store_readonly(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 
@@ -189,7 +189,7 @@ async def test_Mock_store_store_readonly(tmpdir):
 @pytest.mark.asyncio
 async def test_Mock_store_deep_delete(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
-	message = {"content":b"datadatadata"}
+	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
 	annotations = decision_api.get_annotations(message, metadata.headers)
 


### PR DESCRIPTION
Make use of `read_raw` from the latest hop-client to avoid reserializing every message.
Remove the extra wrapper dictionary around the message content from the storage format.

Addresses https://github.com/scimma/archive-core/issues/2