### PR TITLE
Add support for storing payloads with minimal copying

### DIFF
--- a/archive/access_api.py
+++ b/archive/access_api.py
@@ -90,7 +90,10 @@ class Archive_access():
                                                    public=public, direct_upload=direct_upload)
         if await decision_api.is_deemed_duplicate(annotations, metadata, self.db, self.store):
             logging.info(f"Duplicate not stored {annotations}")
-            return (False,"Message with duplicate UUID not stored")
+            return (False,{},"Message with duplicate UUID not stored")
         await self.store.store(payload, metadata, annotations)
         await self.db.insert(metadata, annotations)
-        return (True,"")
+        return (True,
+                {"archive_uuid": annotations["con_text_uuid"],
+                 "is_client_uuid": annotations["con_is_client_uuid"]},
+                "")

--- a/archive/decision_api.py
+++ b/archive/decision_api.py
@@ -53,6 +53,8 @@ def get_text_uuid(headers):
 	for _id in _ids:
 		try:
 			binary_uuid = _id[1]
+			if not isinstance(binary_uuid, bytes):
+				binary_uuid = bytes(binary_uuid)
 			return (str(uuid.UUID(bytes=binary_uuid)), True)
 		except (ValueError, IndexError, TypeError):
 			continue
@@ -72,7 +74,7 @@ def get_annotations(message, headers=[], public: bool=True, direct_upload: bool=
 	text_uuid, is_client_uuid  = get_text_uuid(headers)
 	annotations["con_text_uuid"] = text_uuid
 	annotations["con_is_client_uuid"] = is_client_uuid
-	annotations["con_message_crc32"] =  zlib.crc32(message)
+	annotations["con_message_crc32"] =  message.crc32() if hasattr(message, "crc32") else zlib.crc32(message)
 	annotations["public"] =  public
 	annotations["direct_upload"] =  direct_upload
 	return annotations

--- a/archive/mview.py
+++ b/archive/mview.py
@@ -1,0 +1,319 @@
+import bisect
+import codecs
+from io import BytesIO, StringIO
+import struct
+import zlib
+
+class MMView:
+	"""This class is a segmented memoryview, with some additional features to allow it to be used in
+	more of the places where bytes can (and memoryview cannot) be. it stores a sequence of
+	memoryviews, and attempts to do operations without copying the data from them whenever possible.
+	"""
+
+	def __init__(self, data=None):
+		# self.data is the list of data chunks (which are views)
+		# self.sizes is the list of _cumulative_ sizes
+		if data is None:
+			self.data = []
+			self.sizes = []
+		elif isinstance(data, bytes) or isinstance(data, bytearray):
+			self.data = [memoryview(data)]
+			self.sizes = [len(data)]
+		elif isinstance(data, memoryview):
+			self.data = [data]
+			self.sizes = [len(data)]
+		elif isinstance(data, MMView):
+			self.data = [d for d in data.data]
+			self.sizes = [s for s in data.sizes]
+		else:
+			raise ValueError()
+
+	def append(self, data):
+		if isinstance(data, bytes) or isinstance(data, bytearray):
+			self.data.append(memoryview(data))
+		elif isinstance(data, memoryview):
+			self.data.append(data)
+		elif isinstance(data, MMView):
+			old_size = len(self)
+			self.data.extend(data.data)
+			for size in data.sizes:
+				self.sizes.append(size + old_size)
+			return
+		else:
+			raise ValueError(f"Not able to append object of type {type(data)} to an MMView")
+		self.sizes.append(len(self) + len(data))
+			
+	def __len__(self):
+		if len(self.sizes) == 0:
+			return 0
+		return self.sizes[-1]
+
+	def __eq__(self, other):
+		if len(self) != len(other):
+			return False
+		# not efficient; this is expected to be used mostly for testing
+		for i in range(0, len(self)):
+			if self[i] != other[i]:
+				return False
+		return True
+
+	def __bytes__(self):
+		if len(self.data) == 0:
+			return b""
+		if len(self.data) == 1:
+			return bytes(self.data[0])
+		buf = BytesIO()
+		for chunk in self.data:
+			buf.write(bytes(chunk))
+		return buf.getvalue()
+
+	def __repr__(self):
+		return f"MMView of {len(self)} bytes of data in {len(self.sizes)} chunks"
+
+	def __buffer__(self, flags):
+		if len(self.data) == 1:
+			return self.data[0].__buffer__(flags)
+		else:
+			# there appears to be no way to implement this without copying
+			return memoryview(bytes(self))
+
+	def __getitem__(self, idx):
+		if isinstance(idx, slice):
+			start = idx.start
+			if start is None:
+				start = 0
+			if start >= len(self) or start < 0:
+				raise IndexError()
+			if idx.step is not None and idx.step != 1:
+				raise IndexError("Non-unit steps are not supported")
+			if idx.stop > len(self) or idx.stop < 0:
+				raise IndexError()
+			# find the chunk in which the start lies
+			i = bisect.bisect_right(self.sizes, start)
+			# compute the adjusted index within that chunk
+			base = self.sizes[i - 1] if i else 0
+			local_start = start - (self.sizes[i - 1] if i else 0)
+			length = idx.stop - start
+			if length < (self.sizes[i] - base) - local_start:
+				# the slice is entirely with in this chunk
+				local_stop = local_start + length
+				return MMView(self.data[i][slice(local_start, local_stop, 1)])
+			else:
+				# ugly case: slice extends beyond this chunk
+				# need to build a new object holding the data
+				result = MMView()
+				acc = 0  # bytes accumulated so far
+				while acc < length:
+					base = self.sizes[i - 1] if i else 0
+					avail = (self.sizes[i] - base) - local_start
+					if avail < (length - acc):
+						result.append(self.data[i][local_start:])
+						acc += avail
+					else:
+						result.append(self.data[i][local_start:((length - acc) + local_start)])
+						break
+					local_start = 0
+					i += 1
+				return result
+					
+		else:
+			if idx >= len(self):
+				raise IndexError()
+			if idx < 0:
+				raise IndexError()
+			# find the chunk in which the index lies
+			i = bisect.bisect_right(self.sizes, idx)
+			# compute the adjusted index within that chunk
+			local_idx = idx - (self.sizes[i - 1] if i else 0)
+			return self.data[i][local_idx]
+
+	async def generate(self, max_chunk_size=1024*1024):
+		i = 0
+		for datum in self.data:
+			if len(datum) < max_chunk_size:
+				yield datum
+			else:
+				offset = 0
+				full_len = len(datum)
+				while offset < full_len:
+					length = max_chunk_size
+					if offset + length > full_len:
+						length = full_len - offset
+					yield datum[offset:offset+length]
+					offset += length
+			i += 1
+
+	def index(self, x, i=0, j=-1):
+		if j == -1:
+			j = len(self)
+		if i < 0 or i >= len(self) or j < 0 or j > len(self):
+			raise IndexError()
+		if not isinstance(x, int):
+			raise NotImplementedError("multi-byte targets are not supported")
+		if x < 0 or x > 255:
+			raise ValueError()
+		for k in range(i, j):
+			if self[k] == x:
+				return k
+		raise ValueError()
+
+	def decode(self, *args, **kwargs):
+		if len(self.data) == 1:
+			return codecs.decode(self.data[0], *args, **kwargs)
+		else:
+			buf = StringIO()
+			for datum in self.data:
+				buf.write(codecs.decode(datum, *args, **kwargs))
+			return buf.getvalue()
+
+	def crc32(self):
+		crc = 0
+		for chunk in self.data:
+			crc = zlib.crc32(chunk, crc) & 0xFFFFFFFF
+		return crc
+
+
+def encode_lazy_bson(obj: dict):
+	"""Encode a dictionary as BSON, stored in an MMView.
+	If items within the dictionary are themselves MMViews, those will be incorporated into the
+	output (as binary items).
+	"""
+	def encode_element(buf, bson_type, name, value=None, simple_value_encoder=None):
+		size = 1
+		buf.write(bson_type)
+		if isinstance(name, str):
+			name = name.encode("utf-8")
+		size += len(name) + 1
+		buf.write(name)
+		buf.write(b"\x00")
+		if value is not None and simple_value_encoder is not None:
+			size += simple_value_encoder(buf, value)
+		return size
+
+	def encode_double(buf, val):
+		buf.write(struct.pack("<d", val))
+		return 8
+	
+	def encode_string(buf, val):
+		enc = val.encode("utf-8")
+		s_size = len(enc) + 1
+		buf.write(struct.pack("<i", s_size))
+		buf.write(enc)
+		buf.write(b"\x00")
+		return 4 + s_size
+
+	def encode_binary_header_only(buf, val):
+		b_size = len(val)
+		buf.write(struct.pack("<i", b_size))
+		buf.write(b"\x00")	# always use subtype 0, "Generic binary"
+		return 5
+
+	def encode_binary(buf, val):
+		h_size = encode_binary_header_only(buf, val)
+		buf.write(val)
+		return h_size + len(val)
+
+	def encode_bool(buf, val):
+		buf.write(struct.pack("<b", val))
+		return 1
+
+	def encode_int32(buf, val):
+		buf.write(struct.pack("<i", val))
+		return 4
+
+	def encode_int64(buf, val):
+		buf.write(struct.pack("<q", val))
+		return 8
+
+	def encode_uint64(buf, val):
+		buf.write(struct.pack("<Q", val))
+		return 8
+
+	def encode_document(output, iter):
+		# A document must start with a 32 bit size, and end with a NUL byte.
+		doc_size = 5
+		doc_size_buf = bytearray(4)	 # enough space to hold an int32
+		output.append(doc_size_buf)
+		
+		rbuf = None
+		def running_buffer():
+			nonlocal rbuf
+			if rbuf is None:
+				rbuf = BytesIO()
+			return rbuf
+		def end_buffer():
+			nonlocal rbuf
+			if rbuf is not None:
+				output.append(rbuf.getvalue())
+			rbuf = None
+		
+		for name, value in iter:
+			if isinstance(value, float):
+				doc_size += encode_element(running_buffer(), b"\x01", name, value, encode_double)
+			elif isinstance(value, str):
+				doc_size += encode_element(running_buffer(), b"\x02", name, value, encode_string)
+			elif isinstance(value, dict):
+				# trying to thread the running buffer through a recursive call is too much trouble
+				# for now
+				doc_size += encode_element(running_buffer(), b"\x03", name)
+				end_buffer()
+				doc_size += encode_document(output, value.items())
+			elif isinstance(value, list) or isinstance(value, tuple):
+				# trying to thread the running buffer through a recursive call is too much trouble
+				# for now
+				doc_size += encode_element(running_buffer(), b"\x04", name)
+				end_buffer()
+				doc_size += encode_document(output, zip((str(i) for i in range(len(value))), value))
+			elif isinstance(value, bytes):
+				if len(value) < 1024:
+					doc_size += encode_element(running_buffer(), b"\x05", name, value, encode_binary)
+				else:
+					doc_size += encode_element(running_buffer(), b"\x05", name, value, encode_binary_header_only)
+					end_buffer()
+					doc_size += len(value)
+					output.append(value)
+			elif isinstance(value, memoryview) or isinstance(value, MMView):
+				doc_size += encode_element(running_buffer(), b"\x05", name, value, encode_binary_header_only)
+				end_buffer()
+				doc_size += len(value)
+				output.append(value)
+			# Won't implement: Undefined
+			# Won't implement: ObjectID
+			elif isinstance(value, bool):
+				doc_size += encode_element(running_buffer(), b"\x08", name, value, encode_bool)
+			# TODO: datetime
+			elif value is None:
+				doc_size += encode_element(running_buffer(), b"\x0A", name)
+			# Regex would go here, but probably no one cares?
+			# Won't implement: DB Pointer
+			# Won't implement: Javascript
+			# Won't implement: Symbol
+			# Won't implement: Javascript with scope
+			elif isinstance(value, int):
+				if value<=0x7FFFFFFF and value>=-0x80000000:
+					doc_size += encode_element(running_buffer(), b"\x10", name, value, encode_int32)
+				elif value<=0x7FFFFFFFFFFFFFFF and value>=-0x8000000000000000:
+					doc_size += encode_element(running_buffer(), b"\x12", name, value, encode_int64)
+				elif value>=0 and value<=0xFFFFFFFFFFFFFFFF:
+					doc_size += encode_element(running_buffer(), b"\x11", name, value, encode_uint64)
+				else:
+					raise ValueError("Integer outside of BSON-encodable range")
+			# decimal 128 would go here, but probably no one cares
+			# min key would go here, but probably no one cares?
+			# max key would go here, but probably no one cares?
+			else:
+				raise ValueError(f"Not able to encode {value} as BSON")
+
+		# NUL terminator for document
+		if rbuf is not None:
+			rbuf.write(b"\x00")
+			end_buffer()
+		else:
+			output.append(b"\x00")
+		# overwrite the size buffer with the actual size data
+		doc_size_buf[0:4] = struct.pack("<i", doc_size)
+		return doc_size
+	
+	result = MMView()
+	result.total_size = encode_document(result, obj.items())
+	return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,8 @@ name = "archive-core"
 description = "Core implementation of the Hopskotch Archive"
 requires-python = ">=3.6"
 dependencies = [
-    "aioboto3",
-    "boto3<=1.33.10",
-    "botocore<=1.33.10",
+    "aioboto3==15.1.0",
+    "aiobotocore[boto3]==2.24.0",
     "bson",
     "cython<3 ; python_version < '3.8'", # need this to work around https://github.com/fastavro/fastavro/issues/701
     "fastapi",
@@ -26,3 +25,10 @@ version = "0"
 
 [tool.setuptools]
 packages = ["archive"]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -419,7 +419,7 @@ def temp_minio(tmpdir):
 		with temp_environ(S3_ACCESS_KEY_ID=ms.info.user, S3_SECRET_ACCESS_KEY=ms.info.password):
 			yield {
 				"store_endpoint_url": f"http://{ms.info.host}:{ms.info.port}",
-				"store_region_name": "",
+				"store_region_name": "us-east-1",
 				"store_primary_bucket": "archive",
 				"store_backup_bucket": "backup",
 				"__test_store_server": ms,

--- a/tests/test_decision_api.py
+++ b/tests/test_decision_api.py
@@ -1,4 +1,5 @@
 from hop.io import Metadata
+from io import BytesIO
 import pytest
 import uuid
 
@@ -50,6 +51,16 @@ def test_get_text_uuid():
     uo1 = get_text_uuid([("_id", ui1.bytes)])
     assert uo1[0] == str(ui1)
     assert uo1[1], "UUID should be marked as originating from the client"
+    
+    # A raw UUID viewed via a memoryview should be correctly extracted
+    buf = BytesIO()
+    buf.write(b"prefix")
+    buf.write(ui1.bytes)
+    buf.write(b"suffix")
+    v = memoryview(buf.getvalue())
+    uo1v = get_text_uuid([("_id", v[6:22])])
+    assert uo1v[0] == str(ui1)
+    assert uo1v[1], "UUID should be marked as originating from the client"
     
     ui2 = uuid.uuid4()
     uo2 = get_text_uuid([("_id", ui1.bytes), ("_id", ui2.bytes)])

--- a/tests/test_mview.py
+++ b/tests/test_mview.py
@@ -1,0 +1,459 @@
+import bson
+import pytest
+from zlib import crc32
+
+from archive.mview import MMView, encode_lazy_bson
+
+pytest_plugins = ('pytest_asyncio',)
+
+def test_mmview_construct_empty():
+	m = MMView()
+	assert len(m.data) == 0
+	assert len(m.sizes) == 0
+
+def test_mmview_construct_bytes():
+	d = b"0123"
+	m = MMView(d)
+	assert len(m.data) == 1
+	assert len(m.sizes) == 1
+	assert isinstance(m.data[0], memoryview)
+	assert m.data[0].obj is d
+
+def test_mmview_construct_bytearray():
+	d = bytearray(b"0123")
+	m = MMView(d)
+	assert len(m.data) == 1
+	assert len(m.sizes) == 1
+	assert isinstance(m.data[0], memoryview)
+	assert m.data[0].obj is d
+
+def test_mmview_construct_memoryview():
+	d = b"0123"
+	v = memoryview(d)
+	m = MMView(v)
+	assert len(m.data) == 1
+	assert len(m.sizes) == 1
+	assert isinstance(m.data[0], memoryview)
+	assert m.data[0].obj is d
+
+def test_mmview_construct_mmview():
+	m1 = MMView()
+	m1.append(b"A")
+	m1.append(b"BB")
+	m1.append(b"CCC")
+	m1.append(b"DDDD")
+	m2 = MMView(m1)
+	assert len(m2.data) == 4
+	assert len(m2.sizes) == 4
+	for entry in m2.data:
+		assert isinstance(entry, memoryview)
+	assert m2.sizes == [1, 3, 6, 10]
+	assert m2 == b"ABBCCCDDDD"
+
+def test_mmview_construct_invalid():
+	for obj in ["abc", [1, 2, 3], {"foo": "bar"}]:
+		with pytest.raises(ValueError):
+			m = MMView(obj)
+
+def test_mmview_append_bytes():
+	m = MMView()
+	m.append(b"AAA")
+	assert len(m.data) == 1
+	assert len(m.sizes) == 1
+	assert m.sizes[0] == 3
+	m.append(b"BBBB")
+	assert len(m.data) == 2
+	assert len(m.sizes) == 2
+	assert m.sizes[0] == 3
+	assert m.sizes[1] == 7
+	assert m == b"AAABBBB"
+
+def test_mmview_append_bytearray():
+	m = MMView()
+	m.append(b"AAA")
+	assert len(m.data) == 1
+	assert len(m.sizes) == 1
+	assert m.sizes[0] == 3
+	m.append(bytearray(b"BBBB"))
+	assert len(m.data) == 2
+	assert len(m.sizes) == 2
+	assert m.sizes[0] == 3
+	assert m.sizes[1] == 7
+	assert m == b"AAABBBB"
+
+def test_mmview_append_memoryview():
+	m = MMView()
+	m.append(b"AAA")
+	assert len(m.data) == 1
+	assert len(m.sizes) == 1
+	assert m.sizes[0] == 3
+	m.append(memoryview(b"BBBB"))
+	assert len(m.data) == 2
+	assert len(m.sizes) == 2
+	assert m.sizes[0] == 3
+	assert m.sizes[1] == 7
+	assert m == b"AAABBBB"
+
+def test_mmview_append_mmview():
+	m1 = MMView(b"A")
+	m1.append(b"BB")
+	m2 = MMView(b"CCC")
+	m2.append(b"DDDD")
+	
+	m = MMView()
+	m.append(m1)
+	assert len(m.data) == 2
+	assert len(m.sizes) == 2
+	assert m.sizes[0] == 1
+	assert m.sizes[1] == 3
+	assert m == b"ABB"
+	
+	m.append(m2)
+	assert len(m.data) == 4
+	assert len(m.sizes) == 4
+	assert m.sizes[0] == 1
+	assert m.sizes[1] == 3
+	assert m.sizes[2] == 6
+	assert m.sizes[3] == 10
+	assert m == b"ABBCCCDDDD"
+
+def test_mmview_append_invalid():
+	m = MMView()
+	for obj in ["abc", [1, 2, 3], {"foo": "bar"}]:
+		with pytest.raises(ValueError):
+			m.append(obj)
+
+def test_mmview_len():
+	m = MMView()
+	assert len(m) == 0
+	m.append(b"A")
+	assert len(m) == 1
+	m.append(b"BB")
+	assert len(m) == 3
+	m.append(b"CCC")
+	assert len(m) == 6
+	m.append(b"DDDD")
+	assert len(m) == 10
+
+def test_mmview_eq():
+	m = MMView()
+	assert m == b""
+	assert m != b"A"
+	
+	m.append(b"A")
+	assert m == b"A"
+	assert m != b""
+	assert m != b"B"
+	assert m != b"AA"
+	
+	m.append(b"BB")
+	assert m == b"ABB"
+	assert m != b"AB"
+	assert m != b"AAB"
+	assert m != b"ABBB"
+	
+	m.append(b"CCC")
+	assert m == b"ABBCCC"
+	assert m != b"ABBCC"
+	assert m != b"ABBCCD"
+	assert m != b"ABBCCCC"
+
+def test_mmview_bytes():
+	m = MMView()
+	assert bytes(m) == b""
+	
+	m.append(b"A")
+	assert bytes(m) == b"A"
+	
+	m.append(bytearray(b"BB"))
+	assert bytes(m) == b"ABB"
+	
+	m.append(memoryview(b"XCCCX")[1:4])
+	assert bytes(m) == b"ABBCCC"
+
+def test_mmview_repr():
+	m = MMView(b"A")
+	m.append(b"BB")
+	m.append(b"CCC")
+	m.append(b"DDDD")
+	desc = repr(m)
+	assert " 10 bytes of data" in desc
+	assert "in 4 chunks" in desc
+
+def test_mmview_buffer():
+	m = MMView()
+	v = memoryview(m)
+	assert len(v) == 0
+	
+	m.append(b"AAA")
+	v = memoryview(m)
+	assert len(v) == 3
+	
+	m.append(b"BBBB")
+	v = memoryview(m)
+	assert len(v) == 7
+
+def test_mmview_getitem_single():
+	m = MMView(b"\x00")
+	m.append(b"\x01\x02")
+	m.append(b"\x03\x04\x05")
+	m.append(b"\x06\x07\x08\x09")
+	for i in range(0, 10):
+		assert m[i] == i
+
+def test_mmview_getitem_single_invalid():
+	m = MMView(b"\x00")
+	m.append(b"\x01\x02")
+	m.append(b"\x03\x04\x05")
+	m.append(b"\x06\x07\x08\x09")
+	for bad_idx in [-2, -1, 10, 11]:
+		with pytest.raises(IndexError):
+			m[bad_idx]
+
+def test_mmview_getitem_slice():
+	m = MMView(b"\x00")
+	m.append(b"\x01\x02")
+	m.append(b"\x03\x04\x05")
+	m.append(b"\x06\x07\x08\x09")
+	for start in range(0,10):
+		for stop in range(start + 1, 11):
+			print(f" Extracting slice({start},{stop})")
+			s = m[start:stop]
+			assert len(s) == (stop - start)
+			for i in range(0, stop - start):
+				print(f"  Checking slice element {i}")
+				assert s[i] == (start + i)
+
+def test_mmview_getitem_slice_no_start():
+	m = MMView(b"\x00")
+	m.append(b"\x01\x02")
+	m.append(b"\x03\x04\x05")
+	m.append(b"\x06\x07\x08\x09")
+	for stop in range(1,10):
+		s = m[:stop]
+		assert len(s) == stop
+		for i in range(0, stop):
+				assert s[i] == i
+
+def test_mmview_getitem_slice_invalid():
+	m = MMView(b"ABBCCCDDDD")
+	with pytest.raises(IndexError):
+		m[-1:5]
+	with pytest.raises(IndexError):
+		m[10:5]
+	with pytest.raises(IndexError):
+		m[1:2:7]
+	with pytest.raises(IndexError):
+		m[2:-2]
+	with pytest.raises(IndexError):
+		m[2:12]
+
+@pytest.mark.asyncio
+async def test_mmview_generate():
+	m = MMView(b"A")
+	m.append(b"BB")
+	m.append(b"CCC")
+	m.append(b"DDDD")
+	
+	chunks = []
+	async for chunk in m.generate():
+		chunks.append(chunk)
+	
+	assert len(chunks) == 4
+	assert len(chunks[0]) == 1
+	assert len(chunks[1]) == 2
+	assert len(chunks[2]) == 3
+	assert len(chunks[3]) == 4
+	assert bytes(chunks[0]) == b"A"
+	assert bytes(chunks[1]) == b"BB"
+	assert bytes(chunks[2]) == b"CCC"
+	assert bytes(chunks[3]) == b"DDDD"
+
+@pytest.mark.asyncio
+async def test_mmview_generate_max_size():
+	m = MMView(b"A")
+	m.append(b"BB")
+	m.append(b"CCC")
+	m.append(b"DDDD")
+	
+	chunks = []
+	async for chunk in m.generate(max_chunk_size=2):
+		chunks.append(chunk)
+	
+	assert len(chunks) == 6
+	assert len(chunks[0]) == 1
+	assert len(chunks[1]) == 2
+	assert len(chunks[2]) == 2
+	assert len(chunks[3]) == 1
+	assert len(chunks[4]) == 2
+	assert len(chunks[5]) == 2
+	assert bytes(chunks[0]) == b"A"
+	assert bytes(chunks[1]) == b"BB"
+	assert bytes(chunks[2]) == b"CC"
+	assert bytes(chunks[3]) == b"C"
+	assert bytes(chunks[4]) == b"DD"
+	assert bytes(chunks[5]) == b"DD"
+
+def test_mmview_index():
+	m = MMView(b"A")
+	m.append(b"BB")
+	m.append(b"CCC")
+	m.append(b"DEED")
+	
+	assert m.index(65) == 0
+	assert m.index(66) == 1
+	assert m.index(67) == 3
+	assert m.index(68) == 6
+	assert m.index(69) == 7
+	with pytest.raises(ValueError):
+		m.index(70)
+	
+	with pytest.raises(ValueError):
+		m.index(65, 1)
+	assert m.index(66, 2) == 2
+	assert m.index(67, 4) == 4
+	assert m.index(68, 7) == 9
+	
+	with pytest.raises(ValueError):
+		m.index(67, 0, 3)
+
+def test_mmview_index_invalid():
+	m = MMView(b"A")
+	m.append(b"BB")
+	m.append(b"CCC")
+	m.append(b"DEED")
+	
+	with pytest.raises(IndexError):
+		m.index(65, -1)
+	with pytest.raises(IndexError):
+		m.index(65, 10)
+	with pytest.raises(IndexError):
+		m.index(65, 0, -2)
+	with pytest.raises(IndexError):
+		m.index(65, 0, 11)
+
+	with pytest.raises(ValueError):
+		m.index(-7)
+	with pytest.raises(ValueError):
+		m.index(289)
+
+	with pytest.raises(NotImplementedError):
+		m.index(b"BC")
+
+def test_mmview_decode():
+	assert MMView(b"ABCD").decode("utf-8") == "ABCD"
+	
+	m = MMView(b"A")
+	m.append(b"BB")
+	m.append(b"CCC")
+	m.append(b"DDDD")
+	assert m.decode("utf-8") == "ABBCCCDDDD"
+
+def test_mmview_crc32():
+	m = MMView(b"A")
+	m.append(b"BB")
+	m.append(b"CCC")
+	m.append(b"DDDD")
+	assert m.crc32() == crc32(b"ABBCCCDDDD")
+
+def check_bson(obj):
+	lazy = encode_lazy_bson(obj)
+	eager = bson.dumps(obj)
+	assert lazy == eager
+
+def test_encode_lazy_bson_empty():
+	check_bson({})
+
+def test_encode_lazy_bson_float():
+	check_bson({"foo": 3.1415})
+
+def test_encode_lazy_bson_str():
+	check_bson({"foo": "bar"})
+
+def test_encode_lazy_bson_dict():
+	check_bson({"foo": {"bar": 1.7, "baz": 4.8}})
+
+def test_encode_lazy_bson_list():
+	check_bson({"foo": ["bar", 1.5, "baz", -6.0]})
+
+def test_encode_lazy_bson_tuple():
+	check_bson({"foo": ("bar", 1.5, "baz", -6.0)})
+
+def test_encode_lazy_bson_short_bytes():
+	check_bson({"foo": b"ABCD"})
+
+def test_encode_lazy_bson_long_bytes():
+	check_bson({"foo": b"ABCD"*512})
+
+def obj_index(container, target):
+	index = 0
+	for item in container:
+		if item is target:
+			return index
+		index += 1
+	raise ValueError(f"{target} not found in {container}")
+
+def test_encode_lazy_bson_memoryview():
+	# bson.dumps cannot handle memoryviews, so we must simulate what it should do
+	d = b"ABCD"
+	m = memoryview(d)
+	lazy = encode_lazy_bson({"foo": m})
+	eager = bson.dumps({"foo": d})
+	assert lazy == eager
+	# the lazy data stream should include the original memoryview, this is the whole point of it
+	assert obj_index(lazy.data, m) is not None
+
+def test_encode_lazy_bson_MMView():
+	# bson.dumps cannot handle memoryviews, so we must simulate what it should do
+	m = MMView(b"A")
+	m.append(b"BB")
+	m.append(b"CCC")
+	m.append(b"DDDD")
+	lazy = encode_lazy_bson({"foo": m})
+	eager = bson.dumps({"foo": bytes(m)})
+	assert lazy == eager
+	# the lazy data stream should include the original memoryviews, this is the whole point of it
+	i = 0
+	idx = None
+	for chunk in m.data:
+		if idx is None:
+			idx = obj_index(lazy.data, chunk)
+		else:
+			assert obj_index(lazy.data, chunk) == idx
+		idx = idx + 1
+		i += 1
+
+def test_encode_lazy_bson_bool():
+	check_bson({"true": True, "false": False})
+
+def test_encode_lazy_bson_None():
+	check_bson({"foo": None})
+
+def test_encode_lazy_bson_int32():
+	check_bson({"foo": 0})
+	check_bson({"foo": 1})
+	check_bson({"foo": -1})
+	check_bson({"foo": 65536})
+	check_bson({"foo": -65536})
+	check_bson({"foo": 2147483647})
+	check_bson({"foo": -2147483648})
+
+def test_encode_lazy_bson_int64():
+	check_bson({"foo": 2147483648})
+	check_bson({"foo": -2147483649})
+	check_bson({"foo": 9223372036854775807})
+	check_bson({"foo": -9223372036854775808})
+
+def test_encode_lazy_bson_uint64():
+	check_bson({"foo": 9223372036854775808})
+	check_bson({"foo": 18446744073709551615})
+
+def test_encode_lazy_bson_int_out_of_range():
+	with pytest.raises(ValueError):
+		encode_lazy_bson({"foo": 18446744073709551616})
+	with pytest.raises(ValueError):
+		encode_lazy_bson({"foo": -9223372036854775809})
+
+def test_encode_lazy_bson_invalid_type():
+	with pytest.raises(ValueError):
+		encode_lazy_bson({"foo": bson})  # can't encode a module


### PR DESCRIPTION
These changes enable a reduction in the amount of memory required to add messages to the archive, which is significant for large files uploaded through the REST API. The main mechanism is supporting the use of memoryviews or equivalent to reuse existing data buffers, rather than copying into new buffers. 

The change in memory use can be seen in this graph:
<img width="800" height="600" alt="memory_use" src="https://github.com/user-attachments/assets/8e59ae17-cff1-44dc-bb8a-952543faf4dd" />
where 'Current' is the performance without these changes, 'Ideal' is the perfect case of using exactly enough memory to hold the payload and no more, 'Updated core' is the result from applying these changes, and 'Fully updated' is the result of planned changes to the REST API building off of these to get the maximum benefit. 