### PR TITLE
Bugfixes and cleanup for text indexing

### DIFF
--- a/archive/access_api.py
+++ b/archive/access_api.py
@@ -92,7 +92,10 @@ class Archive_access():
         if await self.decider.is_deemed_duplicate(annotations, metadata, self.db, self.store):
             logging.info(f"Duplicate not stored {annotations}")
             return (False,{},"Message with duplicate UUID not stored")
-        text_to_index = self.decider.get_indexable_text(payload, metadata.headers, annotations)
+        if self.decider.should_index_topic(metadata.topic, metadata.timestamp/1000.):
+            text_to_index = self.decider.get_indexable_text(payload, metadata.headers, annotations)
+        else:
+            text_to_index = None
         await self.store.store(payload, metadata, annotations)
         await self.db.insert(metadata, annotations, text_to_index)
         return (True,

--- a/archive/consumer_api.py
+++ b/archive/consumer_api.py
@@ -27,11 +27,9 @@ import json
 import logging
 import os
 import random
-import re
 import requests
 import time
 from typing import Optional
-from urllib.parse import urlparse
 import uuid
 from hop.io import Stream, StartPosition, list_topics
 from hop import http_scram
@@ -82,23 +80,6 @@ def add_parser_options(parser):
                         help="Number of seconds to wait before rescanning topics to archive",
                         type=int, action=EnvDefault, envvar="KAFKA_TOPIC_REFRESH_INTERVAL",
                         default=600)
-    parser.add_argument("--hopauth-api-url", help="Base URL for the hopauth API",
-                        type=str, action=EnvDefault, envvar="HOPAUTH_API_URL", required=False)
-    parser.add_argument("--hopauth-username",
-                        help="Username of the credential to use for the hopauth API", type=str,
-                        action=EnvDefault, envvar="HOPAUTH_USERNAME", required=False)
-    parser.add_argument("--hopauth-local-auth",
-                        help="Path to a local hop auth TOML file from which to read credentials "
-                        "for the hopauth API", type=str, action=EnvDefault,
-                        envvar="HOPAUTH_LOCAL_AUTH", required=False)
-    parser.add_argument("--hopauth-aws-secret-name",
-                        help="Name of an AWS secret from which to read hopauth API credentials",
-                        type=str, action=EnvDefault, envvar="HOPAUTH_AWS_SECRET_NAME",
-                        required=False)
-    parser.add_argument("--hopauth-aws-secret-region",
-                        help="Name of the AWS region in which to look for the AWS secret from which"
-                        " to read hopauth API credentials", type=str, action=EnvDefault, 
-                        envvar="HOPAUTH_AWS_SECRET_REGION", default="us-west-2", required=False)
 
 
 class Base_consumer:
@@ -170,28 +151,13 @@ class Hop_consumer(Base_consumer):
                                                   config.get("kafka_username", None))
         elif "kafka_aws_secret_name" in config and config["kafka_aws_secret_name"] \
              and "kafka_aws_secret_region" in config and config["kafka_aws_secret_region"]:
-            self.kafka_auth = self.auth_from_secret(config["kafka_aws_secret_region"],
-                                                    config["kafka_aws_secret_name"],
-                                                    config.get("kafka_username", None))
+            self.kafka_auth = utility_api.auth_from_secret(config["kafka_aws_secret_region"],
+                                                           config["kafka_aws_secret_name"],
+                                                           config.get("kafka_username", None))
         else:
             raise RuntimeError("Kafka broker credentials not configured")
-            
-        if "hopauth_username" in config and config["hopauth_username"] \
-          and "HOPAUTH_PASSWORD" in os.environ:
-            self.hopauth_auth = hop.auth.Auth(config["hopauth_username"],
-                                              os.environ["HOPAUTH_PASSWORD"])
-        elif "hopauth_local_auth" in config and config["hopauth_local_auth"]:
-            auth = hop.auth.load_auth(config["hopauth_local_auth"])
-            self.hopauth_auth = hop.auth.select_matching_auth(auth,
-                                                              urlparse(self.auth_api_url).netloc,
-                                                              config.get("hopauth_username", None))
-        elif "hopauth_aws_secret_name" in config and config["hopauth_aws_secret_name"] \
-             and "hopauth_aws_secret_region" in config and config["hopauth_aws_secret_region"]:
-            self.hopauth_auth = self.auth_from_secret(config["hopauth_aws_secret_region"],
-                                                      config["hopauth_aws_secret_name"],
-                                                      config.get("hopauth_username", None))
-        else:
-            raise RuntimeError("Hopauth API credentials not configured")
+        
+        self.hopauth_auth = utility_api.get_hopskotch_credential(config)
 
         self.vetoed_topics    = config.get("kafka_vetoed_topics", [])
         self.refresh_interval = config.get("kafka_topic_refresh_interval", 600)
@@ -204,45 +170,6 @@ class Hop_consumer(Base_consumer):
 
         self.n_recieved = 0
         self.client = None
-    
-    def auth_from_secret(self, secret_region: str, secret_name: str, username: str=""):
-        session = boto3.session.Session()
-        client = session.client(
-            service_name='secretsmanager',
-            region_name=secret_region
-        )
-        resp = client.get_secret_value(
-            SecretId=secret_name
-        )['SecretString']
-        try:
-            data = json.loads(resp)
-            return hop.auth.Auth(data["username"], data["password"])
-        except json.JSONDecodeError:
-            pass
-        
-        # if the data is not JSON try parsing it as a text config file
-        chunks = resp.split(' ')
-        creds = {}
-        last_user=None
-        for chunk in chunks:
-            if match:=re.fullmatch('username="([^"]+)"', chunk):
-                last_user=match[1]
-            elif match:=re.fullmatch('password="([^"]+)"', chunk):
-                if last_user is not None:
-                    creds[last_user]=match[1]
-                last_user=None
-            elif match:=re.fullmatch('user_([^=]+)="([^"]+)"', chunk):
-                creds[match[1]]=match[2]
-                last_user=None
-            else:
-                raise RuntimeError("Text credential list parse error")
-        if username and username in creds:
-            return hop.auth.Auth(username, creds[username], method=hop.auth.SASLMethod.PLAIN)
-        elif len(creds) == 1:
-            username = next(iter(creds))
-            return hop.auth.Auth(username, creds[username], method=hop.auth.SASLMethod.PLAIN)
-        else:
-            raise RuntimeError(f"Ambiguous text-format credential from secret {secret_name}")
 
     def refresh_url(self) -> bool:
         """

--- a/archive/database_api.py
+++ b/archive/database_api.py
@@ -517,7 +517,7 @@ class SQL_db(Base_db):
                     ddl = sqlalchemy.DDL(f.read().replace("%", "%%"))
                 await conn.execute(ddl)
 
-    async def insert(self, metadata, annotations, text_to_index=""):
+    async def insert(self, metadata, annotations, text_to_index=None):
         "insert one record into the DB"
         if self.read_only:
             raise RuntimeError("This database object is set to read-only; insert is forbidden")
@@ -542,13 +542,14 @@ class SQL_db(Base_db):
                     file_name = annotations['file_name'],
                 )
             )
-            await conn.execute(
-                self.ts_table.insert().values(
-                    uuid = annotations['con_text_uuid'],
-                    text_data = sqlalchemy.func.to_tsvector(text_to_index),
-                    text_fully_indexed = annotations.get("text_fully_indexed", False),
+            if text_to_index is not None:
+                await conn.execute(
+                    self.ts_table.insert().values(
+                        uuid = annotations['con_text_uuid'],
+                        text_data = sqlalchemy.func.to_tsvector(text_to_index),
+                        text_fully_indexed = annotations.get("text_fully_indexed", False),
+                    )
                 )
-            )
             await conn.commit()
         self.n_inserted +=1
         self.log()

--- a/archive/decision_api.py
+++ b/archive/decision_api.py
@@ -22,11 +22,14 @@ This moodule supports
 
 import bson
 import logging
+import requests
+import time
 import uuid
 import zlib
 
 import magic
 import hop.models
+from hop import http_scram
 
 from . import utility_api
 
@@ -56,6 +59,21 @@ class Decider:
 		self.magic = magic.Magic(flags=magic.MAGIC_MIME_TYPE)
 		self.text_index_message_size_limit = config.get("text_index_message_size_limit", 1<<22)
 		self.text_index_size_limit = config.get("text_index_size_limit", 1<<14)
+		try:
+			self.hopauth_auth = utility_api.get_hopskotch_credential(config)
+			try:
+				self.auth_api_url = config["hopauth_api_url"]
+			except:
+				raise RuntimeError("Hopauth API URL not configured")
+		except RuntimeError as err:
+			if len(err.args) > 0 and (err.args[0] == "Hopauth API credentials not configured"
+			  or err.args[0] == "Hopauth API URL not configured"):
+				logging.warning(f"{err.args[0]}: Text indexing will be disabled")
+			else:
+				raise
+		self.topic_metadata = {}
+		self.topic_metadata_check_period = 300
+		self.topic_metadata_timestamp = time.time() - self.topic_metadata_check_period
 
 
 	def close(self):
@@ -100,6 +118,8 @@ class Decider:
 	def get_string_header(self, headers, target):
 		"""Get the value of a specific header as a string, if it exists and can be decoded
 		"""
+		if headers is None:
+			return ""
 		for header in headers:
 			if header[0] == target:
 				try:
@@ -128,13 +148,14 @@ class Decider:
 		# first, if the message has a hop _format header, use that
 		# note that we do not break out of the loop after finding a candidate value, 
 		# so that the last value wins; we favor the last because hop-client appends to the headers
-		for header in headers:
-			if header[0] == "_format":
-				logging.debug(f" Found hop format header: {header[1]}")
-				candidate = self.hop_format_to_media_type(header[1])
-				if candidate is not None:
-					format = candidate
-					logging.debug(f" tentative format is {format}")
+		if headers is not None:
+			for header in headers:
+				if header[0] == "_format":
+					logging.debug(f" Found hop format header: {header[1]}")
+					candidate = self.hop_format_to_media_type(header[1])
+					if candidate is not None:
+						format = candidate
+						logging.debug(f" tentative format is {format}")
 			
 		# appliction/octet-stream is not very specific, so we would like to do better if we can
 		if format is not None and format != "application/octet-stream":
@@ -195,22 +216,61 @@ class Decider:
 		return duplicate
 
 
+	def _fetch_topic_metadata(self):
+		if not hasattr(self, "hopauth_auth") or not hasattr(self, "auth_api_url"):
+			# update the timestamp as if we fetched data, to avoid constantly retrying
+			self.topic_metadata_timestamp = time.time()
+			return
+		http_auth = http_scram.SCRAMAuth(self.hopauth_auth, shortcut=True)
+		resp = requests.get(f"{self.auth_api_url}/v1/topics", auth=http_auth)
+		if not resp.ok:
+			raise RuntimeError(f"Failed to contact hopauth API: {resp.status_code}")
+		self.topic_metadata = {t["name"]:t for t in resp.json()}
+		self.topic_metadata_timestamp = time.time()
+
+
+	def should_index_topic(self, topic, msg_time):
+		"""
+		Determine whether a message on a given topic should be text indexed
+		
+		Args:
+		    topic: The name of the topic on which the mesage was sent
+		    msg_time: The timestamp of the message, in seconds (not milliseconds as used by Kafka)
+		"""
+		# compute effective topic name, accounting for large-message offload pseudo-topics
+		offload_suffix = "+oversized"
+		if topic.endswith(offload_suffix):
+			topic = topic[:-len(offload_suffix)]
+		
+		if time.time() > self.topic_metadata_timestamp + self.topic_metadata_check_period:
+			self._fetch_topic_metadata()
+		elif topic not in self.topic_metadata and msg_time > self.topic_metadata_timestamp:
+			# A recent message might arrive on a topic which is unknown because it was created since
+			# the last metadata check, in which case we should update metadata.
+			# It can also be the case that a message is old and on a topic which has since been
+			# deleted, in which case we should not check, as we do not want to check on each old
+			# message.
+			self._fetch_topic_metadata()
+		return topic in self.topic_metadata and self.topic_metadata[topic]["index_archived_text"]
+
+
 	def get_indexable_text(self, message, headers, annotations):
 		chunks = []
 		
 		# try to collect text from headers
 		# ignore reserved headers, whose names start with underscores, 
 		# except the _sender header, which is text and of interest for searching
-		for header in headers:
-			if not header[0].startswith('_') or header[0]=="_sender":
-				try:
-					s = header[1].decode("utf-8")
-				except Exception as ex:
-					# headers may not be text, so treat decoding failures as unimportant
-					pass
-				else:
-					chunks.append(header[0] if not header[0].startswith('_') else header[0][1:])
-					chunks.append(s)
+		if headers is not None:
+			for header in headers:
+				if not header[0].startswith('_') or header[0]=="_sender":
+					try:
+						s = header[1].decode("utf-8")
+					except Exception as ex:
+						# headers may not be text, so treat decoding failures as unimportant
+						pass
+					else:
+						chunks.append(header[0] if not header[0].startswith('_') else header[0][1:])
+						chunks.append(s)
 		
 		# to prevent high memory use from unpacking various formats, only index message contents
 		# if the payload is small enough
@@ -225,6 +285,17 @@ class Decider:
 			logging.warning(f"Extracted {len(text)} bytes of text from a message, "
 			                f"truncating to {self.text_index_size_limit} bytes")
 			text = text[0:self.text_index_size_limit]
+		
+		# Make sure result string is clean of control characters
+		# For now, just deal with ASCII cases
+		text_dirty = False
+		for char in text:
+			c = ord(char)
+			if c < 32 or c == 127:
+				text_dirty = True
+				break
+		if text_dirty:
+			text = ''.join(' ' if ord(c)<32 or ord(c)==127 else c for c in text)
 		return text
 
 

--- a/archive/utility_api.py
+++ b/archive/utility_api.py
@@ -2,9 +2,14 @@
     Utility  functions 
 """
 import argparse
+import boto3
+import hop
+import json
 import logging
 import os
+import re
 import toml
+from urllib.parse import urlparse
 ##################################                                                                                                          
 #   environment                                                                                                                             
 ##################################                                                                                                          
@@ -61,6 +66,81 @@ def add_parser_options(parser):
     parser.add_argument("--log-format", help="Log message format", type=str, action=EnvDefault,
                         envvar="LOG_FORMAT", required=False,
                         default="%(asctime)s:%(filename)s:%(levelname)s:%(message)s")
+    add_hopauth_parser_options(parser)
+
+def add_hopauth_parser_options(parser):
+    parser.add_argument("--hopauth-api-url", help="Base URL for the hopauth API",
+                        type=str, action=EnvDefault, envvar="HOPAUTH_API_URL", required=False)
+    parser.add_argument("--hopauth-username",
+                        help="Username of the credential to use for the hopauth API", type=str,
+                        action=EnvDefault, envvar="HOPAUTH_USERNAME", required=False)
+    parser.add_argument("--hopauth-local-auth",
+                        help="Path to a local hop auth TOML file from which to read credentials "
+                        "for the hopauth API", type=str, action=EnvDefault,
+                        envvar="HOPAUTH_LOCAL_AUTH", required=False)
+    parser.add_argument("--hopauth-aws-secret-name",
+                        help="Name of an AWS secret from which to read hopauth API credentials",
+                        type=str, action=EnvDefault, envvar="HOPAUTH_AWS_SECRET_NAME",
+                        required=False)
+    parser.add_argument("--hopauth-aws-secret-region",
+                        help="Name of the AWS region in which to look for the AWS secret from which"
+                        " to read hopauth API credentials", type=str, action=EnvDefault, 
+                        envvar="HOPAUTH_AWS_SECRET_REGION", default="us-west-2", required=False)
+
+def get_hopskotch_credential(config):
+	if "hopauth_username" in config and config["hopauth_username"] \
+	  and "HOPAUTH_PASSWORD" in os.environ:
+		return hop.auth.Auth(config["hopauth_username"], os.environ["HOPAUTH_PASSWORD"])
+	elif "hopauth_local_auth" in config and config["hopauth_local_auth"]:
+		auth = hop.auth.load_auth(config["hopauth_local_auth"])
+		return hop.auth.select_matching_auth(auth, urlparse(config["hopauth_api_url"]).netloc,
+		                                     config.get("hopauth_username", None))
+	elif "hopauth_aws_secret_name" in config and config["hopauth_aws_secret_name"] \
+		 and "hopauth_aws_secret_region" in config and config["hopauth_aws_secret_region"]:
+		return auth_from_secret(config["hopauth_aws_secret_region"],
+		                        config["hopauth_aws_secret_name"],
+		                        config.get("hopauth_username", None))
+	else:
+		raise RuntimeError("Hopauth API credentials not configured")
+
+def auth_from_secret(secret_region: str, secret_name: str, username: str=""):
+	session = boto3.session.Session()
+	client = session.client(
+		service_name='secretsmanager',
+		region_name=secret_region
+	)
+	resp = client.get_secret_value(
+		SecretId=secret_name
+	)['SecretString']
+	try:
+		data = json.loads(resp)
+		return hop.auth.Auth(data["username"], data["password"])
+	except json.JSONDecodeError:
+		pass
+	
+	# if the data is not JSON try parsing it as a text config file
+	chunks = resp.split(' ')
+	creds = {}
+	last_user=None
+	for chunk in chunks:
+		if match:=re.fullmatch('username="([^"]+)"', chunk):
+			last_user=match[1]
+		elif match:=re.fullmatch('password="([^"]+)"', chunk):
+			if last_user is not None:
+				creds[last_user]=match[1]
+			last_user=None
+		elif match:=re.fullmatch('user_([^=]+)="([^"]+)"', chunk):
+			creds[match[1]]=match[2]
+			last_user=None
+		else:
+			raise RuntimeError("Text credential list parse error")
+	if username and username in creds:
+		return hop.auth.Auth(username, creds[username], method=hop.auth.SASLMethod.PLAIN)
+	elif len(creds) == 1:
+		username = next(iter(creds))
+		return hop.auth.Auth(username, creds[username], method=hop.auth.SASLMethod.PLAIN)
+	else:
+		raise RuntimeError(f"Ambiguous text-format credential from secret {secret_name}")
 
 def make_logging(config):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,18 @@ except ImportError:
 if os.environ.get('POSTGRES_REMOTE_DB',''):
 	import psycopg
 
+class MockHttpResponse:
+	def __init__(self, status, json):
+		self.status_code = status
+		self.json_data = json
+	
+	@property
+	def ok(self):
+		return self.status_code>=200 and self.status_code<=299
+	
+	def json(self):
+		return self.json_data
+
 @contextmanager
 def temp_environ(**vars):
     """

--- a/tests/test_consumer_api.py
+++ b/tests/test_consumer_api.py
@@ -6,9 +6,9 @@ import pytest
 import time
 from unittest import mock
 
-from archive import consumer_api
+from archive import consumer_api, utility_api
 
-from conftest import temp_environ, temp_wd
+from conftest import temp_environ, temp_wd, MockHttpResponse
 
 pytest_plugins = ('pytest_asyncio',)
 
@@ -31,6 +31,7 @@ def test_ConsumerFactory():
 
 def test_add_parser_options(tmpdir):
 	parser = argparse.ArgumentParser()
+	utility_api.add_parser_options(parser)
 	consumer_api.add_parser_options(parser)
 	config = parser.parse_args(["--consumer-type", "hop",
                                 "--kafka-hostname", "example.com",
@@ -74,6 +75,7 @@ def test_add_parser_options(tmpdir):
 	                  HOPAUTH_LOCAL_AUTH="/etc/auth2", HOPAUTH_AWS_SECRET_NAME="shh",
 	                  HOPAUTH_AWS_SECRET_REGION="us-east-6"):
 		parser = argparse.ArgumentParser()
+		utility_api.add_parser_options(parser)
 		consumer_api.add_parser_options(parser)
 		config = parser.parse_args([])
 		assert config.consumer_type == "mock", "Consumer type should be set by the correct environment variable"
@@ -256,17 +258,6 @@ def test_hop_consumer_create_random_group():
 		hc = consumer_api.Hop_consumer(config)
 		assert hc.group_id.startswith(config["kafka_username"])
 		assert "*random*" not in hc.group_id
-
-class MockHttpResponse:
-	def __init__(self, status, json):
-		self.status_code = status
-		self.json_data = json
-	
-	def ok(self):
-		return self.status_code>=200 and self.status_code<=299
-	
-	def json(self):
-		return self.json_data
 
 def test_hop_consumer_refresh_url(tmpdir):
 	config = get_consumer_test_config()

--- a/tests/test_database_api.py
+++ b/tests/test_database_api.py
@@ -13,7 +13,7 @@ from archive import database_api
 from archive import decision_api
 from archive import store_api
 
-from conftest import temp_environ, temp_postgres
+from conftest import temp_environ, temp_postgres, MockHttpResponse
 
 pytest_plugins = ('pytest_asyncio',)
 
@@ -236,9 +236,19 @@ async def test_SQL_db_set_indexed_text(tmpdir):
 	u = uuid.UUID("01234567-aaaa-bbbb-cccc-0123456789de")
 	message = b"datadatadata"
 	metadata = Metadata(topic="t1", partition=0, offset=2, timestamp=356, key="", headers=[("_id",u.bytes)], _raw=None)
-	with decision_api.Decider({}) as decider:
-		annotations = decider.get_annotations(message, metadata.headers)
-		text_to_index = decider.get_indexable_text(message, metadata.headers, annotations)
+	dConfig = {
+		"hopauth_api_url": "http://example.com/api",
+		"hopauth_username": "user"
+	}
+	topic_metadata = [
+		{"name": "t1", "archivable": True, "index_archived_text": True}
+	]
+	with temp_environ(KAFKA_PASSWORD="test-pass", HOPAUTH_PASSWORD="test-api-pass"), \
+	     mock.patch('requests.get', mock.Mock(return_value=MockHttpResponse(200, topic_metadata))):
+		with decision_api.Decider(dConfig) as decider:
+			annotations = decider.get_annotations(message, metadata.headers)
+			text_to_index = decider.get_indexable_text(message, metadata.headers, annotations)
+			print(f"text_to_index: {text_to_index}")
 
 	st = await get_mock_store()
 	# we need to do this to get the last of the required annotations
@@ -273,7 +283,7 @@ async def test_SQL_db_set_indexed_text(tmpdir):
 		tsr = await db.search_message_text("datadatadata")
 		assert len(tsr[0]) == 0, "Text search should not find an un-indexed message"
 		
-		await db.set_indexed_text(u, text_to_index, True, True)
+		await db.set_indexed_text(u, text_to_index, True, False)
 		tsr = await db.search_message_text("datadatadata")
 		assert len(tsr[0]) == 1
 		assert tsr[0][0].uuid == u
@@ -1186,40 +1196,13 @@ async def test_SQL_db_get_messages_not_text_indexed(tmpdir):
 		await db.make_schema()
 		st = await get_mock_store()
 		
-		# SQL_db.insert should never create message records without corresponding text search
-		# records, so we will need to emulate it to create some incomplete records to find
-		
-		async def insert_raw(metadata, annotations):
-			nonlocal db
-			async with db.engine.connect() as conn:
-				await conn.execute(
-					db.messages_table.insert().values(
-						topic = metadata.topic,
-						timestamp = metadata.timestamp,
-						uuid = annotations['con_text_uuid'],
-						size = annotations['size'],
-						key = annotations['key'],
-						bucket = annotations['bucket'],
-						crc32 = annotations['crc32'],
-						is_client_uuid = annotations['con_is_client_uuid'],
-						public = annotations['public'],
-						direct_upload = annotations['direct_upload'],
-						message_crc32 = annotations['con_message_crc32'],
-						title = annotations['title'],
-						sender = annotations['sender'],
-						media_type = annotations['media_type'],
-						file_name = annotations['file_name'],
-					)
-				)
-				await conn.commit()
-		
 		u1 = uuid.uuid4()
 		message = b"datadatadata"
 		m1 = Metadata(topic="t1", partition=0, offset=0, timestamp=356, key="", headers=[("_id",u1.bytes)], _raw=None)
 		with decision_api.Decider({}) as decider:
 			a1 = decider.get_annotations(message, m1.headers)
 		await st.store(message, m1, a1)
-		await db.insert(m1, a1)
+		await db.insert(m1, a1, "")
 		
 		r, n, p = await db.get_messages_not_text_indexed()
 		assert len(r) == 0
@@ -1230,7 +1213,7 @@ async def test_SQL_db_get_messages_not_text_indexed(tmpdir):
 		with decision_api.Decider({}) as decider:
 			a2 = decider.get_annotations(message, m2.headers)
 		await st.store(message, m2, a2)
-		await insert_raw(m2, a2)
+		await db.insert(m2, a2, None)
 		
 		r, n, p = await db.get_messages_not_text_indexed()
 		assert len(r) == 1
@@ -1241,7 +1224,7 @@ async def test_SQL_db_get_messages_not_text_indexed(tmpdir):
 		with decision_api.Decider({}) as decider:
 			a3 = decider.get_annotations(message, m3.headers)
 		await st.store(message, m3, a3)
-		await insert_raw(m3, a3)
+		await db.insert(m3, a3, None)
 		
 		r, n, p = await db.get_messages_not_text_indexed()
 		assert len(r) == 2
@@ -1275,37 +1258,43 @@ async def test_SQL_db_get_messages_not_fully_text_indexed(tmpdir):
 		await db.make_schema()
 		st = await get_mock_store()
 		
-		u1 = uuid.uuid4()
-		message = b"datadatadata"
-		m1 = Metadata(topic="t1", partition=0, offset=0, timestamp=356, key="", headers=[("_id",u1.bytes)], _raw=None)
-		with decision_api.Decider({}) as decider:
-			a1 = decider.get_annotations(message, m1.headers)
-			t1 = decider.get_indexable_text(message, m1.headers, a1)
+		dConfig = {
+			"hopauth_api_url": "http://example.com/api",
+			"hopauth_username": "user"
+		}
+		topic_metadata = [
+			{"name": "t1", "archivable": True, "index_archived_text": True}
+		]
+		with temp_environ(HOPAUTH_PASSWORD="test-api-pass"), \
+			 mock.patch('requests.get', mock.Mock(return_value=MockHttpResponse(200, topic_metadata))):
+			message = b"datadatadata"
+			u1 = uuid.uuid4()
+			m1 = Metadata(topic="t1", partition=0, offset=0, timestamp=356, key="", headers=[("_id",u1.bytes)], _raw=None)
+			u2 = uuid.uuid4()
+			m2 = Metadata(topic="t1", partition=0, offset=0, timestamp=359, key="", headers=[("_id",u2.bytes)], _raw=None)
+			u3 = uuid.uuid4()
+			m3 = Metadata(topic="t1", partition=0, offset=0, timestamp=372, key="", headers=[("_id",u3.bytes)], _raw=None)
+			with decision_api.Decider({}) as decider:
+				a1 = decider.get_annotations(message, m1.headers)
+				t1 = decider.get_indexable_text(message, m1.headers, a1)
+				a2 = decider.get_annotations(message, m2.headers)
+				a3 = decider.get_annotations(message, m3.headers)
 		await st.store(message, m1, a1)
 		await db.insert(m1, a1, t1)
 		
 		r, n, p = await db.get_messages_not_fully_text_indexed()
 		assert len(r) == 0
-		
-		u2 = uuid.uuid4()
-		message = b"datadatadata"
-		m2 = Metadata(topic="t1", partition=0, offset=0, timestamp=359, key="", headers=[("_id",u2.bytes)], _raw=None)
-		with decision_api.Decider({}) as decider:
-			a2 = decider.get_annotations(message, m2.headers)
+			
 		await st.store(message, m2, a2)
-		await db.insert(m2, a2)
+		await db.insert(m2, a2, "")
 		
 		r, n, p = await db.get_messages_not_fully_text_indexed()
 		assert len(r) == 1
 		assert r[0].uuid == u2
 		
-		u3 = uuid.uuid4()
-		message = b"datadatadata"
-		m3 = Metadata(topic="t1", partition=0, offset=0, timestamp=372, key="", headers=[("_id",u3.bytes)], _raw=None)
-		with decision_api.Decider({}) as decider:
-			a3 = decider.get_annotations(message, m3.headers)
+		
 		await st.store(message, m3, a3)
-		await db.insert(m3, a3)
+		await db.insert(m3, a3, "")
 		
 		r, n, p = await db.get_messages_not_fully_text_indexed()
 		assert len(r) == 2

--- a/tests/test_decision_api.py
+++ b/tests/test_decision_api.py
@@ -2,14 +2,65 @@ from hop.io import Metadata
 import hop.io
 import hop.models
 from io import BytesIO
+import logging
 import pytest
+from unittest.mock import patch, MagicMock
 import uuid
 
 from archive import database_api
 from archive import decision_api
 from archive import store_api
 
+from conftest import temp_environ, MockHttpResponse
+
 pytest_plugins = ('pytest_asyncio',)
+
+
+decider_test_config = {
+    "hopauth_username": "Harpo",
+    "hopauth_api_url": "https://example.com/hopauth",
+    "text_index_message_size_limit": 1<<23,
+    "text_index_size_limit": 1<<16,
+}
+
+def test_decision_init():
+    with temp_environ(HOPAUTH_PASSWORD="Swordfish"):
+        dec = decision_api.Decider(decider_test_config)
+        assert dec.hopauth_auth.username == decider_test_config["hopauth_username"]
+        assert dec.hopauth_auth.password == "Swordfish"
+        assert dec.auth_api_url == decider_test_config["hopauth_api_url"]
+        assert dec.text_index_message_size_limit == decider_test_config["text_index_message_size_limit"]
+        assert dec.text_index_size_limit == decider_test_config["text_index_size_limit"]
+
+def test_decision_init_no_cred(caplog):
+    config_no_api_username = dict(decider_test_config)
+    del config_no_api_username["hopauth_username"]
+    dec_no_cred = decision_api.Decider(config_no_api_username)
+    assert len(caplog.record_tuples) == 1
+    assert caplog.record_tuples[0][1] == logging.WARNING
+    assert "Hopauth API credentials not configured" in caplog.record_tuples[0][2]
+    assert "Text indexing will be disabled" in caplog.record_tuples[0][2]
+
+def test_decision_init_no_api_url(caplog):
+    with temp_environ(HOPAUTH_PASSWORD="Swordfish"):
+        config_no_api_url = dict(decider_test_config)
+        del config_no_api_url["hopauth_api_url"]
+        dec_no_url = decision_api.Decider(config_no_api_url)
+        assert len(caplog.record_tuples) == 1
+        assert caplog.record_tuples[0][1] == logging.WARNING
+        assert "Hopauth API URL not configured" in caplog.record_tuples[0][2]
+        assert "Text indexing will be disabled" in caplog.record_tuples[0][2]
+
+def test_decision_init_bad_credfile(tmpdir):
+    with temp_environ(XDG_CONFIG_HOME=str(tmpdir)), \
+            pytest.raises(RuntimeError):
+        credpath = str(tmpdir)+"/credfile"
+        with open(credpath, 'w') as f:
+            f.write("blah")
+        config_no_api_username = dict(decider_test_config)
+        del config_no_api_username["hopauth_username"]
+        config_no_api_username["hopauth_local_auth"] = credpath
+        dec_no_cred = decision_api.Decider(config_no_api_username)
 
 @pytest.mark.asyncio
 async def test_is_content_identical():
@@ -81,6 +132,8 @@ def test_get_text_uuid():
 
 def test_get_string_header():
     with decision_api.Decider({}) as d:
+        assert d.get_string_header(None, "foo") == ""
+        
         assert d.get_string_header([("foo", b"bar")], "foo") == "bar"
         
         assert d.get_string_header([("foo", b"bar"), ("foo", b"baz")], "foo") == "bar"
@@ -287,6 +340,69 @@ async def test_is_deemed_duplicate():
         assert not a4["con_is_client_uuid"]
         await store(m4[0], m4[1], a4)
 
+def test__fetch_topic_metadata():
+    topic_metadata = [
+        {"name": "t1", "archivable": True, "index_archived_text": True},
+        {"name": "t2", "archivable": True, "index_archived_text": False},
+    ]
+    with temp_environ(HOPAUTH_PASSWORD="Swordfish"):
+        with patch("archive.decision_api.time.time", MagicMock(return_value=0.0)):
+            dec = decision_api.Decider(decider_test_config)
+    
+    with patch("archive.decision_api.time.time", MagicMock(return_value=1.0)), \
+            patch('requests.get', MagicMock(return_value=MockHttpResponse(200, topic_metadata))):
+        dec._fetch_topic_metadata()
+    assert dec.topic_metadata_timestamp == 1.0
+    for record in topic_metadata:
+        assert record["name"] in dec.topic_metadata
+        assert dec.topic_metadata[record["name"]] == record
+    
+    with patch("archive.decision_api.time.time", MagicMock(return_value=2.0)), \
+            patch('requests.get', MagicMock(return_value=MockHttpResponse(500, []))), \
+            pytest.raises(RuntimeError):
+        dec._fetch_topic_metadata()
+    # fetch time should not change after failed fetch
+    assert dec.topic_metadata_timestamp == 1.0
+
+def test_should_index_topic():
+    topic_metadata = [
+        {"name": "t1", "archivable": True, "index_archived_text": True},
+        {"name": "t2", "archivable": True, "index_archived_text": False},
+    ]
+    with temp_environ(HOPAUTH_PASSWORD="Swordfish"):
+        with patch("archive.decision_api.time.time", MagicMock(return_value=0.0)):
+            dec = decision_api.Decider(decider_test_config)
+    
+    with patch("archive.decision_api.time.time", MagicMock(return_value=10.0)), \
+            patch('requests.get', MagicMock(return_value=MockHttpResponse(200, topic_metadata))):
+        si = dec.should_index_topic("t1", 5)
+        assert si
+        assert dec.topic_metadata_timestamp == 10.0
+        
+        si = dec.should_index_topic("t1+oversized", 6)
+        assert si, "offloaded large messages should be treated according to the base topic"
+        
+        si = dec.should_index_topic("t2", 7)
+        assert not si
+        
+        si = dec.should_index_topic("t2+oversized", 8)
+        assert not si, "offloaded large messages should be treated according to the base topic"
+        
+        si = dec.should_index_topic("t3", -1000)
+        assert not si, "an old message on an unknown topic should not be indexed"
+    
+    topic_metadata.append({"name": "t3", "archivable": True, "index_archived_text": True})
+    with patch("archive.decision_api.time.time", MagicMock(return_value=20.0)), \
+            patch('requests.get', MagicMock(return_value=MockHttpResponse(200, topic_metadata))):
+        si = dec.should_index_topic("t3", 15)
+        assert si, "a new message on an unknown topic should trigger a new metadata lookup"
+    
+    with patch("archive.decision_api.time.time", MagicMock(return_value=30.0)), \
+            patch('requests.get', MagicMock(return_value=MockHttpResponse(200, topic_metadata))):
+        si = dec.should_index_topic("t4", 25)
+        assert not si, "a new message on an unknown topic should not be indexed " \
+                       "if it is still unknown after the new lookup"
+
 @pytest.mark.asyncio
 async def test_get_indexable_text_from_headers():
     u = uuid.uuid4()
@@ -395,7 +511,8 @@ async def test_get_indexable_text_message():
         for key, value in gcncircular.header.items():
             assert key in text
             assert value in text
-        assert gcncircular.body in text
+        for word in gcncircular.body.split():
+            assert word in text
         
         gcntextnotice = hop.models.GCNTextNotice.load(
             b'TITLE:            GCN/AMON NOTICE\n'


### PR DESCRIPTION
Implement checking the hopauth API to determine which topics should be indexed for text search.
Handle indexing messages with no headers.
Clean control characters out of indexed text.