### PR TITLE
Add dois/doi_messages tables and data-access methods

### DIFF
--- a/archive/access_api.py
+++ b/archive/access_api.py
@@ -165,3 +165,16 @@ class Archive_access():
 
     async def mark_message_retracted(self, msg_id, retracted: bool=True):
         return await self.db.mark_message_retracted(msg_id, retracted)
+
+    async def record_doi(self, doi, record_url, title, created_by, message_uuids):
+        """
+        Record a newly minted DOI and the messages it covers.
+        """
+        return await self.db.insert_doi(doi, record_url, title, created_by, message_uuids)
+
+    async def find_dois_for_messages(self, message_uuids):
+        """
+        Find every existing DOI associated with any of the given message UUIDs.
+        See database_api.SQL_db.find_dois_for_messages for the return shape.
+        """
+        return await self.db.find_dois_for_messages(message_uuids)

--- a/archive/database_api.py
+++ b/archive/database_api.py
@@ -524,6 +524,22 @@ class SQL_db(Base_db):
             Column("l_timestamp", sqlalchemy.dialects.postgresql.BIGINT, nullable=False),
             Column("n_messages", sqlalchemy.dialects.postgresql.BIGINT, nullable=False),
         )
+        self.dois_table = sqlalchemy.Table(
+            "dois",
+            self.db_meta,
+            Column("id", sqlalchemy.dialects.postgresql.BIGINT, primary_key=True),
+            Column("doi", sqlalchemy.dialects.postgresql.TEXT, nullable=False),
+            Column("record_url", sqlalchemy.dialects.postgresql.TEXT),
+            Column("title", sqlalchemy.dialects.postgresql.TEXT),
+            Column("created_by", sqlalchemy.dialects.postgresql.TEXT),
+            Column("created_at", sqlalchemy.dialects.postgresql.TIMESTAMP(timezone=True)),
+        )
+        self.doi_messages_table = sqlalchemy.Table(
+            "doi_messages",
+            self.db_meta,
+            Column("doi_id", sqlalchemy.dialects.postgresql.BIGINT, nullable=False),
+            Column("message_uuid", sqlalchemy.dialects.postgresql.UUID, nullable=False),
+        )
 
     async def close(self):
         await self.engine.dispose()
@@ -921,6 +937,78 @@ class SQL_db(Base_db):
                    .where(self.messages_table.c.uuid == msg_id)
             result = await conn.execute(stmt)
             await conn.commit()
+
+    async def insert_doi(self, doi, record_url, title, created_by, message_uuids):
+        """
+        Record a newly minted DOI and the set of messages it covers.
+
+        Returns: the new row's id in the dois table.
+        """
+        if self.read_only:
+            raise RuntimeError("This database object is set to read-only; insert_doi is forbidden")
+
+        async with self.engine.connect() as conn:
+            result = await conn.execute(
+                self.dois_table.insert().values(
+                    doi = doi,
+                    record_url = record_url,
+                    title = title,
+                    created_by = created_by,
+                ).returning(self.dois_table.c.id)
+            )
+            doi_id = result.scalar()
+
+            await conn.execute(
+                self.doi_messages_table.insert(),
+                [{"doi_id": doi_id, "message_uuid": message_uuid} for message_uuid in message_uuids]
+            )
+            await conn.commit()
+        return doi_id
+
+    async def find_dois_for_messages(self, message_uuids):
+        """
+        Find every existing DOI associated with any of the given message
+        UUIDs.
+
+        Returns: A sequence of rows, one per (doi, message_uuid) pairing,
+                each including the DOI's id, doi string, record_url, and
+                title, plus the specific message_uuid matched. The caller
+                is responsible for grouping these by doi_id to reconstruct
+                each DOI's full associated message set.
+        """
+        async with self.engine.connect() as conn:
+            # First, find every doi_id that has ANY overlap with the given uuids.
+            overlapping_doi_ids_result = await conn.execute(
+                sqlalchemy.select(self.doi_messages_table.c.doi_id)
+                    .distinct()
+                    .where(self.doi_messages_table.c.message_uuid.in_(bindparam("uuids")))
+                , {"uuids": message_uuids}
+            )
+            overlapping_doi_ids = [row[0] for row in overlapping_doi_ids_result.all()]
+            if not overlapping_doi_ids:
+                return []
+ 
+            # Then, for each of those DOIs, fetch their FULL message set (not
+            # just the overlapping ones) so the caller can determine whether
+            # a candidate set is an exact match or only a partial overlap.
+            result = await conn.execute(
+                sqlalchemy.select(
+                    self.dois_table.c.id,
+                    self.dois_table.c.doi,
+                    self.dois_table.c.record_url,
+                    self.dois_table.c.title,
+                    self.doi_messages_table.c.message_uuid,
+                )
+                .select_from(
+                    self.dois_table.join(
+                        self.doi_messages_table,
+                        self.dois_table.c.id == self.doi_messages_table.c.doi_id
+                    )
+                )
+                .where(self.dois_table.c.id.in_(bindparam("doi_ids")))
+                , {"doi_ids": overlapping_doi_ids}
+            )
+            return result.all()
 
 
 class AWS_db(SQL_db):

--- a/archive/migrations/0006_add_doi_tracking.sql
+++ b/archive/migrations/0006_add_doi_tracking.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS dois (
+	id BIGSERIAL PRIMARY KEY,
+	doi text NOT NULL,
+	record_url text,
+	title text,
+	created_by text,
+	created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS dois_doi_idx ON dois
+USING btree (doi);
+
+CREATE TABLE IF NOT EXISTS doi_messages (
+	doi_id bigint NOT NULL REFERENCES dois (id) ON DELETE CASCADE,
+	message_uuid uuid NOT NULL,
+	PRIMARY KEY (doi_id, message_uuid)
+);
+
+CREATE INDEX IF NOT EXISTS doi_messages_message_uuid_idx ON doi_messages
+USING btree (message_uuid);
+
+-- end the transaction
+COMMIT;


### PR DESCRIPTION
Adds two tables to support tracking which messages have been used to mint DOIs, enabling duplicate-DOI detection for consumers like Hermes without depending on Zenodo's API for that lookup.

`archive/migrations/0006_add_doi_tracking.sql`
- `dois`: one row per minted DOI (doi string, record URL, title, creator, timestamp). Unique index on `doi`.
- `doi_messages`: many-to-many between DOIs and message UUIDs. Composite primary key (`doi_id`, `message_uuid`), cascade-delete FK to `dois`, and an index on `message_uuid` for fast reverse lookup ("which DOIs is this message part of?").

No FK to `messages.uuid` — that column only has a non-unique index, not a unique constraint, so a hard FK could break inserts in edge cases already handled elsewhere (duplicate message ingestion).

`archive/database_api.py`
- `sqlalchemy.Table` declarations for both new tables, following the existing pattern used for `messages`/`topics`.
- `insert_doi(doi, record_url, title, created_by, message_uuids)`: inserts one `dois` row plus its associated `doi_messages` rows in a single transaction.
- `find_dois_for_messages(message_uuids)`: given a candidate set of UUIDs, returns every message belonging to any DOI that overlaps at all with that set (not just the overlapping members). This lets callers distinguish an exact-duplicate package (same message set, same size) from a partial overlap (a message reused inside a different, larger package) using only counts — without needing a second round-trip query.

`archive/access_api.py`
- Thin pass-through wrapper methods (`record_doi`, `find_dois_for_messages`) added to `Archive_access`, matching the existing convention. No business logic here, consistent with every other method in this class.